### PR TITLE
.github: Add helm chart linting to CI workflows (#10283)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,9 @@ A scheduled job which scans images released from both the Open Source and Enterp
 
 To run the vulnerability locally, check out [the security scanner README](https://github.com/solo-io/gloo/tree/main/docs/cmd/securityscanutils)
 
+## [Lint Helm Charts](./lint-helm.yaml)
+Perform linting on project [Helm Charts](../../install/helm/README.md).
+
 ## Future Work
 It would be great to add support for issue comment directives. This would mean that commenting `/sig-ci` would signal CI to run, or `/skip-ci` would auto-succeed CI.
 

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -1,0 +1,25 @@
+name: Lint Helm Charts
+
+on:
+  pull_request: { }
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint-helm:
+    name: Lint Helm Charts
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: ${{ matrix.kube-version.helm || 'latest' }}
+    - name: Lint Helm Charts
+      run: make lint-kgateway-charts

--- a/install/helm/kgateway-crds/Chart.yaml
+++ b/install/helm/kgateway-crds/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: kgateway-crds
 description: A Helm chart for the kgateway project CRDs
+icon: https://raw.githubusercontent.com/kgateway-dev/kgateway.dev/main/static/favicon.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/install/helm/kgateway/Chart.yaml
+++ b/install/helm/kgateway/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: kgateway
 description: A Helm chart for the kgateway project
+icon: https://raw.githubusercontent.com/kgateway-dev/kgateway.dev/main/static/favicon.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
# Description

  * Add helm chart linting to CI workflows (#10283)
  * Fix missing icons on kgateway and kgateway-crd helm charts

# Changelog

```release-note
NONE
```